### PR TITLE
[KUBOS-340] Updating overlay to run user init scripts

### DIFF
--- a/overlay/etc/inittab
+++ b/overlay/etc/inittab
@@ -31,7 +31,7 @@ ttyS0::respawn:/sbin/getty -L  ttyS0 115200 vt100 # GENERIC_SERIAL
 #::ctrlaltdel:/sbin/reboot
 
 # Stuff to do before rebooting
-::shutdown:/etc/init.d/rcK
 ::shutdown:/home/etc/init.d/rcK
+::shutdown:/etc/init.d/rcK
 ::shutdown:/sbin/swapoff -a
 ::shutdown:/bin/umount -a -r

--- a/overlay/etc/inittab
+++ b/overlay/etc/inittab
@@ -1,0 +1,37 @@
+# /etc/inittab
+#
+# Copyright (C) 2001 Erik Andersen <andersen@codepoet.org>
+#
+# Note: BusyBox init doesn't support runlevels.  The runlevels field is
+# completely ignored by BusyBox init. If you want runlevels, use
+# sysvinit.
+#
+# Format for each entry: <id>:<runlevels>:<action>:<process>
+#
+# id        == tty to run on, or empty for /dev/console
+# runlevels == ignored
+# action    == one of sysinit, respawn, askfirst, wait, and once
+# process   == program to run
+
+# Startup the system
+::sysinit:/bin/mount -t proc proc /proc
+::sysinit:/bin/mount -o remount,rw /
+::sysinit:/bin/mkdir -p /dev/pts
+::sysinit:/bin/mkdir -p /dev/shm
+::sysinit:/bin/mount -a
+::sysinit:/bin/hostname -F /etc/hostname
+# now run any rc scripts
+::sysinit:/etc/init.d/rcS
+::sysinit:/home/etc/init.d/rcS
+
+# Put a getty on the serial port
+ttyS0::respawn:/sbin/getty -L  ttyS0 115200 vt100 # GENERIC_SERIAL
+
+# Stuff to do for the 3-finger salute
+#::ctrlaltdel:/sbin/reboot
+
+# Stuff to do before rebooting
+::shutdown:/etc/init.d/rcK
+::shutdown:/home/etc/init.d/rcK
+::shutdown:/sbin/swapoff -a
+::shutdown:/bin/umount -a -r

--- a/overlay/home/etc/init.d/rcK
+++ b/overlay/home/etc/init.d/rcK
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+
+# Stop all init scripts in /home/etc/init.d
+# executing them in reversed numerical order.
+#
+for i in $(ls -r /home/etc/init.d/S??*) ;do
+
+     # Ignore dangling symlinks (if any).
+     [ ! -f "$i" ] && continue
+
+     case "$i" in
+	*.sh)
+	    # Source shell script for speed.
+	    (
+		trap - INT QUIT TSTP
+		set stop
+		. $i
+	    )
+	    ;;
+	*)
+	    # No sh extension, so fork subprocess.
+	    $i stop
+	    ;;
+    esac
+done
+

--- a/overlay/home/etc/init.d/rcS
+++ b/overlay/home/etc/init.d/rcS
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+
+# Start all init scripts in /home/etc/init.d
+# executing them in numerical order.
+#
+for i in /home/etc/init.d/S??* ;do
+
+     # Ignore dangling symlinks (if any).
+     [ ! -f "$i" ] && continue
+
+     case "$i" in
+	*.sh)
+	    # Source shell script for speed.
+	    (
+		trap - INT QUIT TSTP
+		set start
+		. $i
+	    )
+	    ;;
+	*)
+	    # No sh extension, so fork subprocess.
+	    $i start
+	    ;;
+    esac
+done
+


### PR DESCRIPTION
User init scripts will be installed into /home/etc/init.d.
Updated inittab to call new rcS script to start them after starting all of the system/Kubos scripts in /etc/init.d. Reverse order for calling rcK to stop everything during shutdown