### PR TITLE
KUBOS-407 Building the telemetry service module from the main kubos repo

### DIFF
--- a/package/kubos-telemetry/kubos-telemetry.mk
+++ b/package/kubos-telemetry/kubos-telemetry.mk
@@ -6,17 +6,28 @@
 KUBOS_TELEMETRY_VERSION = master
 KUBOS_TELEMETRY_LICENSE = Apache-2.0
 KUBOS_TELEMETRY_LICENSE_FILES = LICENSE
-KUBOS_TELEMETRY_SITE = git://github.com/kubostech/kubos-linux-telemetry
+KUBOS_TELEMETRY_SITE = git://github.com/kubostech/kubos
+# The path to the telemetry module in the kubos repo
+KUBOS_REPO_TELEM_PATH = services/telemetry/telemetry
+# The path from the telemetry module to the build artifact directory
+KUBOS_ARTIFACT_BUILD_PATH = build/kubos-linux-isis-gcc/ym/cmocka/existing
+
 
 #Use the Kubos SDK to build the telemetry application
 define KUBOS_TELEMETRY_BUILD_CMDS
-	cd $(@D); PATH=$(PATH):/usr/bin/iobc_toolchain/usr/bin kubos -t kubos-linux-isis-gcc build
+	cd $(@D)/$(KUBOS_REPO_TELEM_PATH) && \
+	PATH=$(PATH):/usr/bin/iobc_toolchain/usr/bin && \
+	rm -rf test && \
+	kubos link -a && \
+	kubos -t kubos-linux-isis-gcc build
 endef
 
 #Install the application into the rootfs file system
 define KUBOS_TELEMETRY_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/sbin
-	$(INSTALL) -D -m 0755 $(@D)/build/kubos-linux-isis-gcc/source/kubos-telemetry $(TARGET_DIR)/usr/sbin
+	# The cmocka.a build artifact is what the project is configured (Most likely not right) to build currently.
+	# Point this at the right build artifact when the telemetry service build configuration is fixed..
+	$(INSTALL) -D -m 0755 $(@D)/$(KUBOS_REPO_TELEM_PATH)/$(KUBOS_ARTIFACT_BUILD_PATH)/cmocka.a $(TARGET_DIR)/usr/sbin
 endef
 
 #Install the init script

--- a/package/kubos-telemetry/kubos-telemetry.mk
+++ b/package/kubos-telemetry/kubos-telemetry.mk
@@ -3,7 +3,8 @@
 # KubOS Telemetry Service
 #
 ###############################################
-KUBOS_TELEMETRY_VERSION = master
+UPDATE_DUMMY := $(shell kubos update) #unused dummy variable to run update before getting the version...
+KUBOS_TELEMETRY_VERSION := $(shell kubos versions 2>&1 | grep recent | awk '{print $$7}')
 KUBOS_TELEMETRY_LICENSE = Apache-2.0
 KUBOS_TELEMETRY_LICENSE_FILES = LICENSE
 KUBOS_TELEMETRY_SITE = git://github.com/kubostech/kubos

--- a/package/kubos-telemetry/kubos-telemetry.mk
+++ b/package/kubos-telemetry/kubos-telemetry.mk
@@ -8,16 +8,15 @@ KUBOS_TELEMETRY_LICENSE = Apache-2.0
 KUBOS_TELEMETRY_LICENSE_FILES = LICENSE
 KUBOS_TELEMETRY_SITE = git://github.com/kubostech/kubos
 # The path to the telemetry module in the kubos repo
-KUBOS_REPO_TELEM_PATH = services/telemetry/telemetry
+KUBOS_REPO_TELEM_PATH = linux-telemetry-service
 # The path from the telemetry module to the build artifact directory
-KUBOS_ARTIFACT_BUILD_PATH = build/kubos-linux-isis-gcc/ym/cmocka/existing
+KUBOS_ARTIFACT_BUILD_PATH = build/kubos-linux-isis-gcc/source
 
 
 #Use the Kubos SDK to build the telemetry application
 define KUBOS_TELEMETRY_BUILD_CMDS
 	cd $(@D)/$(KUBOS_REPO_TELEM_PATH) && \
 	PATH=$(PATH):/usr/bin/iobc_toolchain/usr/bin && \
-	rm -rf test && \
 	kubos link -a && \
 	kubos -t kubos-linux-isis-gcc build
 endef
@@ -25,9 +24,8 @@ endef
 #Install the application into the rootfs file system
 define KUBOS_TELEMETRY_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/sbin
-	# The cmocka.a build artifact is what the project is configured (Most likely not right) to build currently.
-	# Point this at the right build artifact when the telemetry service build configuration is fixed..
-	$(INSTALL) -D -m 0755 $(@D)/$(KUBOS_REPO_TELEM_PATH)/$(KUBOS_ARTIFACT_BUILD_PATH)/cmocka.a $(TARGET_DIR)/usr/sbin
+	$(INSTALL) -D -m 0755 $(@D)/$(KUBOS_REPO_TELEM_PATH)/$(KUBOS_ARTIFACT_BUILD_PATH)/linux-telemetry-service \
+		$(TARGET_DIR)/usr/sbin
 endef
 
 #Install the init script

--- a/package/kubos-telemetry/kubos-telemetry.mk
+++ b/package/kubos-telemetry/kubos-telemetry.mk
@@ -35,12 +35,12 @@ define KUBOS_TELEMETRY_INSTALL_INIT_SYSV
 endef
 
 kubos-telemetry-fullclean: kubos-telemetry-clean-for-reconfigure kubos-telemetry-dirclean
-	rm -f $(BUILD_DIR)/kubos-telemetry-master/.stamp_downloaded
-	rm -f $(DL_DIR)/kubos-telemetry-master.tar.gz
+	rm -f $(BUILD_DIR)/kubos-telemetry-$(KUBOS_TELEMETRY_VERSION)/.stamp_downloaded
+	rm -f $(DL_DIR)/kubos-telemetry-$(KUBOS_TELEMETRY_VERSION).tar.gz
 
 
 kubos-telemetry-clean: kubos-telemetry-clean-for-rebuild
-	cd $(BUILD_DIR)/kubos-telemetry-master; kubos clean
+	cd $(BUILD_DIR)/kubos-telemetry-$(KUBOS_TELEMETRY_VERSION); kubos clean
 	cd $(TARGET_DIR)/etc/init.d; rm -f S*kubos-telemetry
 
 $(eval $(generic-package))


### PR DESCRIPTION
This PR implements the functionality to pull the kubos repo and build the telemetry service module as a buildroot package.

There's a couple of issues with the telemetry module that have surfaced here:
 * The build artifact created by the telemetry build configuration is a static library.
 * The test directory code contains some compiler errors (with the iOBC tool chain)