### PR TITLE
KUBOS-410 Initial integration test circle config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker pull kubostech/kubos-dev:latest
+
+test:
+  override:
+      - docker run -t -v $PWD:$PWD -w $PWD kubostech/kubos-dev:latest $PWD/test.sh

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+board="at91sam9g20isis"
+buildroot_tar="buildroot-2016.11.tar.gz"
+buildroot_url="https://buildroot.uclibc.org/downloads/$buildroot_tar"
+
+cd .. #cd out of the kubos-linux-build directory
+
+kubos update
+
+echo "getting buildroot"
+
+wget $buildroot_url && tar xvzf $buildroot_tar && rm $buildroot_tar
+
+cd ./buildroot*
+
+make BR2_EXTERNAL=../kubos-linux-build ${board}_defconfig
+
+echo "STARTING BUILD"
+
+make
+


### PR DESCRIPTION
This is a super basic integration test that builds the Kubos-Linux image. 

It takes about an hour to run so running it as a nightly build may be a better way to go depending on how it works initially. 