### PR TITLE
[KUBOS-423] Adding SPI0 +supervisor support

### DIFF
--- a/board/kubos/at91sam9g20isis/at91sam9g20isis.dts
+++ b/board/kubos/at91sam9g20isis/at91sam9g20isis.dts
@@ -22,6 +22,10 @@
 	model = "Kubos at91sam9g20isis";
 	compatible = "kubos,at91sam9g20isis", "atmel,at91sam9g20", "atmel,at91sam9";
 
+	aliases {
+		spi0 = &spi0;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -89,6 +93,23 @@
 							<AT91_PIOC 2 AT91_PERIPH_GPIO AT91_PINCTRL_PULL_UP_DEGLITCH>;	/* PC2 gpio CD pin pull up and deglitch */
 					};
 				};
+
+				spi0 {
+					pinctrl_spi0: spi0-0 {
+						atmel,pins =
+							<AT91_PIOA 0 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA0 periph A SPI0_MISO pin */
+							 AT91_PIOA 1 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PA1 periph A SPI0_MOSI pin */
+							 AT91_PIOA 2 AT91_PERIPH_A AT91_PINCTRL_NONE>;	/* PA2 periph A SPI0_SPCK pin */
+					};
+				};
+
+				spi0_cs {
+					pinctrl_spi0_cs: spi0-cs {
+						atmel,pins =
+							<AT91_PIOB 17 AT91_PERIPH_GPIO AT91_PINCTRL_PULL_UP>;
+					};
+				};
+
 			};
 
 			dbgu: serial@fffff200 {
@@ -129,7 +150,15 @@
 			};
 
 			spi0: spi@fffc8000 {
-				cs-gpios = <0>, <&pioC 11 0>, <0>, <0>;
+				pinctrl-0 = <&pinctrl_spi0 &pinctrl_spi0_cs>;
+				cs-gpios = <0>, <0>, <&pioB 17 0>;
+				status = "okay";
+				super0: super@0 {
+					compatible = "isis,supervisor";
+					reg = <2>;
+					spi-max-frequency = <1000000>;
+					status = "okay";
+				};
 			};
 
 			shdwc@fffffd10 {

--- a/board/kubos/at91sam9g20isis/linux/0002-Kubos-spidev.patch
+++ b/board/kubos/at91sam9g20isis/linux/0002-Kubos-spidev.patch
@@ -1,0 +1,11 @@
+--- old-linux-4.4.23/drivers/spi/spidev.c	2016-09-30 03:20:43.000000000 -0500
++++ linux-4.4.23/drivers/spi/spidev.c	2017-03-27 15:40:24.765495000 -0500
+@@ -695,6 +695,8 @@
+ static const struct of_device_id spidev_dt_ids[] = {
+ 	{ .compatible = "rohm,dh2228fv" },
+ 	{ .compatible = "lineartechnology,ltc2488" },
++	{ .compatible = "isis,supervisor" },
++	{ .compatible = "spidev" },
+ 	{},
+ };
+ MODULE_DEVICE_TABLE(of, spidev_dt_ids);


### PR DESCRIPTION
Updating the linux device tree to add the iOBC supervisor as a generic SPI0 device. It can be accessed in userland through the `/dev/spi0.2` device. (The name is /dev/{spiBus}.{chipSelect}).

The tiny patch is because of [this](https://github.com/raspberrypi/linux/issues/1054). By manually defining "spidev" as a valid ID, I'm muting the stack trace that would otherwise get dumped. It doesn't actually change any functionality. Also adding a device name specifically for the supervisor, since it doesn't follow the usual SPI communication protocol (delayed bytes)

This has not been formally tested yet, since there is a fair amount of groundwork in order to send a minimal message to the supervisor. Testing will be done as part of [KUBOS-445](https://kubostech.atlassian.net/browse/KUBOS-445)

TODO: Test a from-scratch build of the linux kernel and dtb with the changes.