### PR TITLE
KUBOS-439 Lazy loading the kubos version

### DIFF
--- a/package/kubos-command-and-control/kubos-command-and-control.mk
+++ b/package/kubos-command-and-control/kubos-command-and-control.mk
@@ -3,8 +3,8 @@
 # KubOS Command and Control Service
 #
 ###############################################
-UPDATE_DUMMY := $(shell kubos update) #unused dummy variable to run update before getting the version...
-KUBOS_COMMAND_AND_CONTROL_VERSION := $(shell kubos versions 2>&1 | grep recent | awk '{print $$7}')
+UPDATE_DUMMY = $(shell kubos update) #unused dummy variable to run update before getting the version...
+KUBOS_COMMAND_AND_CONTROL_VERSION = $(shell kubos versions 2>&1 | grep recent | awk '{print $$7}')
 KUBOS_COMMAND_AND_CONTROL_LICENSE = Apache-2.0
 KUBOS_COMMAND_AND_CONTROL_LICENSE_FILES = LICENSE
 KUBOS_COMMAND_AND_CONTROL_SITE = git://github.com/kubostech/kubos
@@ -16,11 +16,10 @@ KUBOS_CNC_ARTIFACT_BUILD_PATH = build/kubos-linux-isis-gcc/source
 
 #Use the Kubos SDK to build the command-and-control application
 define KUBOS_COMMAND_AND_CONTROL_BUILD_CMDS
-	echo "VERSION: $(KUBOS_COMMAND_AND_CONTROL_VERSION)" && \
+	cd $(@D) && \
+	./tools/kubos_link.py --sys --app $(KUBOS_REPO_COMMAND_AND_CONTROL_PATH) && \
 	cd $(@D)/$(KUBOS_REPO_COMMAND_AND_CONTROL_PATH) && \
 	PATH=$(PATH):/usr/bin/iobc_toolchain/usr/bin && \
-	kubos use $(KUBOS_COMMAND_AND_CONTROL_VERSION) && \
-	kubos link -a && \
 	kubos -t kubos-linux-isis-gcc build
 endef
 

--- a/package/kubos-telemetry/kubos-telemetry.mk
+++ b/package/kubos-telemetry/kubos-telemetry.mk
@@ -3,8 +3,8 @@
 # KubOS Telemetry Service
 #
 ###############################################
-UPDATE_DUMMY := $(shell kubos update) #unused dummy variable to run update before getting the version...
-KUBOS_TELEMETRY_VERSION := $(shell kubos versions 2>&1 | grep recent | awk '{print $$7}')
+UPDATE_DUMMY = $(shell kubos update) #unused dummy variable to run update before getting the version...
+KUBOS_TELEMETRY_VERSION = $(shell kubos versions 2>&1 | grep recent | awk '{print $$7}')
 KUBOS_TELEMETRY_LICENSE = Apache-2.0
 KUBOS_TELEMETRY_LICENSE_FILES = LICENSE
 KUBOS_TELEMETRY_SITE = git://github.com/kubostech/kubos
@@ -16,9 +16,10 @@ KUBOS_ARTIFACT_BUILD_PATH = build/kubos-linux-isis-gcc/source
 
 #Use the Kubos SDK to build the telemetry application
 define KUBOS_TELEMETRY_BUILD_CMDS
+	cd $(@D) && \
+	./tools/kubos_link.py --sys --app $(KUBOS_REPO_TELEM_PATH) && \
 	cd $(@D)/$(KUBOS_REPO_TELEM_PATH) && \
 	PATH=$(PATH):/usr/bin/iobc_toolchain/usr/bin && \
-	kubos link -a && \
 	kubos -t kubos-linux-isis-gcc build
 endef
 


### PR DESCRIPTION
This should run the kubos `update` command much less frequently. 

This PR also includes  linking the cloned modules rather than kubos-cli modules. This is beneficial as links modules that have already been checked out rather than duplicating a checkout call through the CLI as well.