### PR TITLE
[KUBOS-466] Migrating files to /home/system and adding new user

### DIFF
--- a/board/kubos/at91sam9g20isis/users.txt
+++ b/board/kubos/at91sam9g20isis/users.txt
@@ -1,4 +1,2 @@
 kubos -1 users -1 =Kubos123 /home/kubos /bin/bash -
-usr -1 users -1 !- /home/usr - -
-etc -1 users -1 !- /home/etc - -
-var -1 users -1 !- /home/var - -
+system -1 users -1 !- /home/system - -

--- a/overlay/etc/init.d/rcK
+++ b/overlay/etc/init.d/rcK
@@ -3,7 +3,7 @@
 # Stop all init scripts in /home/etc/init.d
 # executing them in reversed numerical order.
 #
-for i in $(ls -r /home/etc/init.d/S??* && ls -r /etc/init.d/S??*) ;do
+for i in $(ls -r /home/system/etc/init.d/S??* && ls -r /etc/init.d/S??*) ;do
 
      # Ignore dangling symlinks (if any).
      [ ! -f "$i" ] && continue

--- a/overlay/etc/init.d/rcS
+++ b/overlay/etc/init.d/rcS
@@ -3,7 +3,7 @@
 # Start all init scripts in /etc/init.d
 # executing them in numerical order.
 #
-for i in $(ls /etc/init.d/S??* && ls /home/etc/init.d/S??*) ;do
+for i in $(ls /etc/init.d/S??* && ls /home/system/etc/init.d/S??*) ;do
 
      # Ignore dangling symlinks (if any).
      [ ! -f "$i" ] && continue

--- a/overlay/etc/profile
+++ b/overlay/etc/profile
@@ -1,4 +1,4 @@
-export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/home/usr/bin
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/home/system/usr/bin
 
 if [ "$PS1" ]; then
 	if [ "`id -u`" -eq 0 ]; then


### PR DESCRIPTION
Moving /home/{usr,etc,var} directories to be under /home/system/{usr,etc,var}. This keeps us within the Linux standard where everything under the /home directory belongs to a user.