### PR TITLE
[KUBOS-526] Fixing default user shell and home directory

### DIFF
--- a/board/kubos/at91sam9g20isis/users.txt
+++ b/board/kubos/at91sam9g20isis/users.txt
@@ -1,2 +1,2 @@
-kubos -1 users -1 =Kubos123 /home/kubos /bin/bash -
+kubos -1 users -1 =Kubos123 /home/kubos /bin/sh -
 system -1 users -1 !- /home/system - -

--- a/overlay/etc/init.d/S99kubos-verify
+++ b/overlay/etc/init.d/S99kubos-verify
@@ -14,13 +14,15 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
  #
- # KubOS Linux Boot Healthcheck
- #
- # At the moment, this simply resets a couple UBoot variables, so that we know that
- # we booted successfully during the next reboot.
+ # KubOS Linux Boot Finalization
  #
 
+# Update the U-Boot variables to indicate that we have successfully booted
 fw_setenv kubos_curr_tried 0
 fw_setenv bootcount 0
+
+# Make sure the default user's home directory exists
+mkdir -p /home/kubos
+chown kubos /home/kubos
 
 exit 0

--- a/overlay/etc/init.d/S99kubos-verify
+++ b/overlay/etc/init.d/S99kubos-verify
@@ -23,6 +23,6 @@ fw_setenv bootcount 0
 
 # Make sure the default user's home directory exists
 mkdir -p /home/kubos
-chown kubos /home/kubos
+chown -R kubos /home/kubos
 
 exit 0


### PR DESCRIPTION
Tested the default user 'kubos' and found a couple problems:

1. The default user shell is supposed to be /bin/sh, which comes from Busybox.

2. Since the '/home' directory exists outside of the rootfs (because it's actually the user data partition), we can't use the normal rootfs overlay to create the default /home/kubos directory. So instead we'll create it, if necessary, at boot time.