### PR TITLE
Turning on desired BBB buses

### DIFF
--- a/board/kubos/pumpkin-mbm2/pumpkin-mbm2.dts
+++ b/board/kubos/pumpkin-mbm2/pumpkin-mbm2.dts
@@ -20,4 +20,57 @@
 / {
 	model = "Pumpkin MBM2";
 	compatible = "pumpkin,mbm2", "ti,am335x-bone-black", "ti,am335x-bone", "ti,am33xx";
+
 };
+
+&am33xx_pinmux {
+
+	i2c1_pins: pinmux_i2c1_pins {
+		pinctrl-single,pins = <
+			0x158 (PIN_INPUT_PULLUP | MUX_MODE2)	/* spi0_d1.i2c1_sda */
+			0x15c (PIN_INPUT_PULLUP | MUX_MODE2)	/* spi0_cs0.i2c1_scl */
+		>;
+	};
+
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1_pins>;
+	clock-frequency = <100000>;
+
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&uart3 {
+	status = "okay";
+};
+
+&uart4 {
+	status = "okay";
+};
+
+&uart5 {
+	status = "okay";
+};
+
+&spi1 {
+	status = "okay";
+
+	/* This will be replaced with the SD over SPI definition in the future */
+        spidev@1 {
+		spi-max-frequency = <24000000>;
+		reg = <0>;
+		compatible = "linux,spidev";
+        };
+};
+
+


### PR DESCRIPTION
**PR Overview**:

- Turning on the buses which Pumpkin needs, but aren't enabled with the default BBB device tree

**Documentation**:

Documentation changes have been made in kubostech/kubos#172

Note: The SPI bus isn't documented. This is because the user's shouldn't be messing with it. The only chip select pin available will be dedicated to the SD over SPI device.

**Integration Tests**:

- Integration tests have not yet been added for the MBM2 board