### PR TITLE
Fix default IP Address for BBB / Pumpkin MBM2

### DIFF
--- a/board/kubos/beaglebone-black/overlay/etc/network/interfaces
+++ b/board/kubos/beaglebone-black/overlay/etc/network/interfaces
@@ -5,5 +5,5 @@ iface lo inet loopback
 # Update the 'address' value to set a custom static IP
 auto eth0
 iface eth0 inet static
-	address 168.168.2.20
+	address 10.0.2.20
 	netmask 255.255.255.0

--- a/board/kubos/pumpkin-mbm2/overlay/etc/network/interfaces
+++ b/board/kubos/pumpkin-mbm2/overlay/etc/network/interfaces
@@ -5,5 +5,5 @@ iface lo inet loopback
 # Update the 'address' value to set a custom static IP
 auto eth0
 iface eth0 inet static
-	address 168.168.2.20
+	address 10.0.2.20
 	netmask 255.255.255.0


### PR DESCRIPTION
Docs updated at https://github.com/kubostech/kubos/pull/220

Default IP clashes with public IP ranges.