### PR TITLE
Fix tool scripts trying to execute the BASE_DIR default set.

### DIFF
--- a/tools/format-image.sh
+++ b/tools/format-image.sh
@@ -69,7 +69,7 @@ do
       	  ;;
     esac
 done
-BASE_DIR:=../../buildroot-2016.11/${output}
+: ${BASE_DIR:=../../buildroot-2016.11/${output}}
 
 if [ "${package}" -gt "1" ] && [ ! ${rflag} ]; then
     echo "-t target must be specified in order to build kernel" >&2

--- a/tools/format-sd.sh
+++ b/tools/format-sd.sh
@@ -60,7 +60,7 @@ do
       	  ;;
     esac
 done
-BASE_DIR:=../../buildroot-2016.11/output
+: ${BASE_DIR:=../../buildroot-2016.11/output}
 
 if ${wipe}; then
   echo '\nWiping SD card. This may take a while...'

--- a/tools/kubos-kernel.sh
+++ b/tools/kubos-kernel.sh
@@ -40,7 +40,7 @@ do
 	    ;;
     esac
 done
-BASE_DIR:=../../buildroot-2016.11/${output}
+: ${BASE_DIR:=../../buildroot-2016.11/${output}}
 
 # Build the package
 ${BASE_DIR}/build/uboot-${branch}/tools/mkimage -f ${input} kubos-kernel.itb

--- a/tools/kubos-nor-package.sh
+++ b/tools/kubos-nor-package.sh
@@ -40,7 +40,7 @@ do
 	    ;;
     esac
 done
-BASE_DIR:=../../buildroot-2016.11/output
+: ${BASE_DIR:=../../buildroot-2016.11/output}
 
 # Build the package
 ${BASE_DIR}/build/uboot-${branch}/tools/mkimage -f ${input} kpack-nor-${version}.itb

--- a/tools/kubos-package.sh
+++ b/tools/kubos-package.sh
@@ -56,7 +56,7 @@ do
 	    ;;
     esac
 done
-BASE_DIR:=../../buildroot-2016.11/${output}
+: ${BASE_DIR:=../../buildroot-2016.11/${output}}
 
 if ! ${rflag}
 then


### PR DESCRIPTION
**PR Overview**:

Afraid I broke things in #68 
Sorry 🤦‍♂️ 
`:` is a bash no-op, which prevents bash trying to execute the default arg to BASE_DIR (See https://stackoverflow.com/a/4437588 )

The scripts themselves don't actually run until #72 is merged. Let me know if they should be combined.