### PR TITLE
Fix more hashbangs.

### DIFF
--- a/common/overlay/etc/init.d/S99kubos-verify
+++ b/common/overlay/etc/init.d/S99kubos-verify
@@ -1,21 +1,21 @@
- #!/bin/sh
- #
- # Copyright (C) 2017 Kubos Corporation
- #
- # Licensed under the Apache License, Version 2.0 (the "License");
- # you may not use this file except in compliance with the License.
- # You may obtain a copy of the License at
- #
- #     http://www.apache.org/licenses/LICENSE-2.0
- #
- # Unless required by applicable law or agreed to in writing, software
- # distributed under the License is distributed on an "AS IS" BASIS,
- # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- # See the License for the specific language governing permissions and
- # limitations under the License.
- #
- # KubOS Linux Boot Finalization
- #
+#!/bin/sh
+#
+# Copyright (C) 2017 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# KubOS Linux Boot Finalization
+#
 
 # Update the U-Boot variables to indicate that we have successfully booted
 fw_setenv kubos_curr_tried 0


### PR DESCRIPTION
**PR Overview**:

Because of the spaces at the front of this script, the init script was *NEVER* being run, meaning bootcount was being continually increased, causing every 3rd boot after a flash to attempt recovery.
This took *way* too long to debug.

**Documentation**:
No documentation changes are needed

**Integration Tests**:
Unsure if you have a testing framework for this...?