### PR TITLE
Enabling iOBC SPI Bus 1 Access

### DIFF
--- a/board/kubos/at91sam9g20isis/iobc-common.dtsi
+++ b/board/kubos/at91sam9g20isis/iobc-common.dtsi
@@ -24,6 +24,7 @@
 
 	aliases {
 		spi0 = &spi0;
+		spi1 = &spi1;
 	};
 
 	leds {
@@ -110,6 +111,24 @@
 					};
 				};
 
+				spi1 {
+					pinctrl_spi1: spi1-0 {
+						atmel,pins =
+							<AT91_PIOB 0 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PB0 periph A SPI1_MISO pin */
+							 AT91_PIOB 1 AT91_PERIPH_A AT91_PINCTRL_PULL_UP	/* PB1 periph A SPI1_MOSI pin */
+							 AT91_PIOB 2 AT91_PERIPH_A AT91_PINCTRL_NONE>;	/* PB2 periph A SPI1_SPCK pin */
+					};
+				};
+
+				spi1_cs {
+					pinctrl_spi1_cs: spi1-cs {
+						atmel,pins =
+							<AT91_PIOB 3 AT91_PERIPH_A AT91_PINCTRL_PULL_UP
+							 AT91_PIOC 5 AT91_PERIPH_B AT91_PINCTRL_PULL_UP
+							 AT91_PIOC 4 AT91_PERIPH_B AT91_PINCTRL_PULL_UP>;
+					};
+				};
+
 				i2c_gpio0 {
 					pinctrl_i2c_gpio0: i2c_gpio0-0 {
 						atmel,pins =
@@ -180,6 +199,30 @@
 					compatible = "isis,supervisor";
 					reg = <2>;
 					spi-max-frequency = <1000000>;
+					status = "okay";
+				};
+			};
+
+			spi1: spi@fffcc000 {
+				pinctrl-0 = <&pinctrl_spi1 &pinctrl_spi1_cs>;
+				cs-gpios = <&pioB 3 0>, <&pioC 5 0>, <&pioC 4 0>;
+				status = "okay";
+				cs0@0 {
+					compatible = "spidev";
+					reg = <0>;
+					spi-max-frequency = <133000000>;
+					status = "okay";
+				};
+				cs1@0 {
+					compatible = "spidev";
+					reg = <1>;
+					spi-max-frequency = <133000000>;
+					status = "okay";
+				};
+				cs2@0 {
+					compatible = "spidev";
+					reg = <2>;
+					spi-max-frequency = <133000000>;
 					status = "okay";
 				};
 			};


### PR DESCRIPTION
**PR Overview**:

- Updating the iOBC's device tree to define the second SPI bus to KubOS Linux (available through the daughterboard). This bus comes with 3 chip select pins, which are defined as generic SPI devices.

**Documentation**:

kubostech/kubos#221

**Integration Tests**:

kubostech/kubos#221
