### PR TITLE
Upgrading to BuildRoot LTS 2017.02.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ Enter the new folder
 
     $ cd kubos-linux
   
-Download BuildRoot-2016.11 (more current versions of BuildRoot may work as well, but all testing has been done against 2016.11)
+Download BuildRoot-2017.02 (more current versions of BuildRoot may work as well,
+but all testing has been done against 2017.02)
 
-    $ wget https://buildroot.uclibc.org/downloads/buildroot-2016.11.tar.gz && tar xvzf buildroot-2016.11.tar.gz && rm buildroot-2016.11.tar.gz
+.. note:: All Kubos documentation will refer to v2017.02.8, which is the latest version of the LTS release at the time of this writing.
+
+    $ wget https://buildroot.uclibc.org/downloads/buildroot-2017.02.8.tar.gz && tar xvzf buildroot-2017.02.8.tar.gz && rm buildroot-2017.02.8.tar.gz
   
 Pull the kubos-linux-build repo
 
@@ -50,7 +53,7 @@ Pull the kubos-linux-build repo
   
 Move into the buildroot directory
 
-    $ cd buildroot-2016.11
+    $ cd buildroot-2017.02.8
   
 Point BuildRoot to the external kubos-linux-build folder and tell it which configuration you want to run (config files are located in
 kubos-linux-build/configs)
@@ -67,7 +70,7 @@ and it will go much more quickly (<5 min).
 
 BuildRoot documentation can be found [**here**](https://buildroot.org/docs.html)
 
-The generated files will be located in buildroot-2016.11/output/images.  They are:
+The generated files will be located in buildroot-2017.02.8/output/images.  They are:
 
 - uboot.bin   - The U-Boot binary
 - zImage      - The compressed Linux kernel file

--- a/README.md
+++ b/README.md
@@ -32,7 +32,19 @@ This folder contains the BuildRoot configuration files needed to build each OBC 
 
 ## Installation
 
-Create new folder
+In order to build KubOS Linux, two components are needed:
+
+- The [kubos-linux-build repo](https://github.com/kubostech/kubos-linux-build) - Contains the configurations, patches, and extra tools needed to build KubOS Linux
+- [BuildRoot](https://buildroot.org/) - The actual build system
+
+These components should be setup as children of the same parent directory. 
+There are several commands and variables in the build process which use relative file paths to navigate between the components.
+
+After the environment has been set up, all build commands will be run from the BuildRoot directory unless otherwise stated.
+
+To set up a build environment and build KubOS Linux:
+
+Create a new parent folder to contain the build environment
 
     $ mkdir kubos-linux
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-buildroot_tar="buildroot-2016.11.tar.gz"
+buildroot_tar="buildroot-2017.02.8.tar.gz"
 buildroot_url="https://buildroot.uclibc.org/downloads/$buildroot_tar"
 
 board="$KUBOS_BOARD"

--- a/tools/format-image.sh
+++ b/tools/format-image.sh
@@ -69,7 +69,7 @@ do
       	  ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2016.11/${output}}
+: ${BASE_DIR:=../../buildroot-2017.02.8/${output}}
 
 if [ "${package}" -gt "1" ] && [ ! ${rflag} ]; then
     echo "-t target must be specified in order to build kernel" >&2

--- a/tools/format-sd.sh
+++ b/tools/format-sd.sh
@@ -60,7 +60,7 @@ do
       	  ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2016.11/output}
+: ${BASE_DIR:=../../buildroot-2017.02.8/output}
 
 if ${wipe}; then
   echo '\nWiping SD card. This may take a while...'

--- a/tools/kpack-NOR.its
+++ b/tools/kpack-NOR.its
@@ -25,7 +25,7 @@
 
 	images {
 		dtb@1 {
-			data = /incbin/("./../../buildroot-2016.11/output/images/at91sam9g20isis.dtb");
+			data = /incbin/("./../../buildroot-2017.02.8/output/images/at91sam9g20isis.dtb");
 			type = "firmware";
 			arch = "arm";
 			os = "linux";

--- a/tools/kubos-kernel.sh
+++ b/tools/kubos-kernel.sh
@@ -40,7 +40,7 @@ do
 	    ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2016.11/${output}}
+: ${BASE_DIR:=../../buildroot-2017.02.8/${output}}
 
 # Build the package
 ${BASE_DIR}/build/uboot-${branch}/tools/mkimage -f ${input} kubos-kernel.itb

--- a/tools/kubos-nor-package.sh
+++ b/tools/kubos-nor-package.sh
@@ -40,7 +40,7 @@ do
 	    ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2016.11/output}
+: ${BASE_DIR:=../../buildroot-2017.02.8/output}
 
 # Build the package
 ${BASE_DIR}/build/uboot-${branch}/tools/mkimage -f ${input} kpack-nor-${version}.itb

--- a/tools/kubos-package.sh
+++ b/tools/kubos-package.sh
@@ -56,7 +56,7 @@ do
 	    ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2016.11/${output}}
+: ${BASE_DIR:=../../buildroot-2017.02.8/${output}}
 
 if ! ${rflag}
 then


### PR DESCRIPTION
Updating all documentation and scripts to refer to the current version of the BuildRoot LTS release